### PR TITLE
Fix: browse button alignment

### DIFF
--- a/src/webview/style.css
+++ b/src/webview/style.css
@@ -541,6 +541,10 @@ vscode-button {
   width: 100%;
 }
 
+.debug-tools-table tr.details-row:not(.extra-details-row) .grid-group-div {
+  align-items: flex-end;
+}
+
 .debug-tools-table .grid-group-div vscode-text-field {
   flex: 1 1 auto;
   min-width: 200px;


### PR DESCRIPTION
Before: 
<img width="800" height="100" alt="image" src="https://github.com/user-attachments/assets/570d6e2c-fe83-4456-95ef-3ac8db0215e6" />

After:
<img width="1488" height="201" alt="image" src="https://github.com/user-attachments/assets/74f9b51c-ba5e-4c77-9ba8-7cb4a61e60fb" />
