### PR TITLE
Improve app discovery refresh performance

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,6 +121,36 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const zephyrAppProvider = new ZephyrApplicationDataProvider();
 	vscode.window.registerTreeDataProvider('zephyr-workbench-app-explorer', zephyrAppProvider);
+	let appRefreshSuspendCount = 0;
+	let appRefreshPending = false;
+
+	const flushAppRefresh = () => {
+		appRefreshPending = false;
+		zephyrAppProvider.refresh();
+	};
+
+	const requestAppRefresh = () => {
+		// Project create/import updates workspace folders, tasks, and several settings in sequence.
+		// While that batch is running, collapse repeated refresh requests into one final refresh.
+		if (appRefreshSuspendCount > 0) {
+			appRefreshPending = true;
+			return;
+		}
+		flushAppRefresh();
+	};
+
+	const withAppRefreshBatch = async <T>(fn: () => Promise<T>): Promise<T> => {
+		appRefreshSuspendCount++;
+		try {
+			return await fn();
+		} finally {
+			appRefreshSuspendCount--;
+			// Only the outermost batch flushes, so nested callers still produce a single tree refresh.
+			if (appRefreshSuspendCount === 0 && appRefreshPending) {
+				flushAppRefresh();
+			}
+		}
+	};
 
 	const zephyrToolsCommandProvider = new ZephyrHostToolsCommandProvider();
 	vscode.window.registerTreeDataProvider('zephyr-workbench-tools-explorer', zephyrToolsCommandProvider);
@@ -2012,50 +2042,51 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			vscode.window.withProgress({
-				location: vscode.ProgressLocation.Notification,
-				title: "Creating new application...",
-				cancellable: false,
-			}, async (progress, token) => {
-				let projLoc: string;
-				if (projectLoc.length === 0) {
-					projLoc = zephyrSample.rootDir.fsPath;
-				} else {
-					let projectPath = path.join(projectLoc, projectName);
-					if (fileExists(projectPath)) {
-						vscode.window.showErrorMessage(`The folder [${projectPath}] already exists. Please change the project name or its location.`);
-						return;
-					}
-					projLoc = copySampleSync(zephyrSample.rootDir.fsPath, projectPath);
-				}
-				await addWorkspaceFolder(projLoc);
-
-				let workspaceFolder = getWorkspaceFolder(projLoc);
-				if (workspaceFolder) {
-					if (debugPreset) {
-						await debugPresetContent(workspaceFolder.uri.fsPath);
-					}
-
-					await setDefaultProjectSettings(workspaceFolder, westWorkspace, zephyrBoard, toolchain);
-					await createTasksJson(workspaceFolder);
-					await createExtensionsJson(workspaceFolder);
-					await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder).update(ZEPHYR_WORKBENCH_BUILD_PRISTINE_SETTING_KEY, pristineValue, vscode.ConfigurationTarget.WorkspaceFolder);
-
-					// Create a local Python venv if requested
-					if (venvMode === 'local') {
-						const venvPath = await createLocalVenv(context, workspaceFolder);
-						if (venvPath) {
-							await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder)
-								.update(ZEPHYR_WORKBENCH_VENV_PATH_SETTING_KEY, venvPath, vscode.ConfigurationTarget.WorkspaceFolder);
+			await withAppRefreshBatch(async () => {
+				await vscode.window.withProgress({
+					location: vscode.ProgressLocation.Notification,
+					title: "Creating new application...",
+					cancellable: false,
+				}, async (progress, token) => {
+					let projLoc: string;
+					if (projectLoc.length === 0) {
+						projLoc = zephyrSample.rootDir.fsPath;
+					} else {
+						let projectPath = path.join(projectLoc, projectName);
+						if (fileExists(projectPath)) {
+							vscode.window.showErrorMessage(`The folder [${projectPath}] already exists. Please change the project name or its location.`);
+							return;
 						}
+						projLoc = copySampleSync(zephyrSample.rootDir.fsPath, projectPath);
 					}
-					CreateZephyrAppPanel.currentPanel?.dispose();
+					await addWorkspaceFolder(projLoc);
 
-					vscode.window.showInformationMessage(`New Application '${workspaceFolder.name}' created !`);
-					zephyrAppProvider.refresh();
-				}
-			}
-			);
+					let workspaceFolder = getWorkspaceFolder(projLoc);
+					if (workspaceFolder) {
+						if (debugPreset) {
+							await debugPresetContent(workspaceFolder.uri.fsPath);
+						}
+
+						await setDefaultProjectSettings(workspaceFolder, westWorkspace, zephyrBoard, toolchain);
+						await createTasksJson(workspaceFolder);
+						await createExtensionsJson(workspaceFolder);
+						await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder).update(ZEPHYR_WORKBENCH_BUILD_PRISTINE_SETTING_KEY, pristineValue, vscode.ConfigurationTarget.WorkspaceFolder);
+
+						// Create a local Python venv if requested
+						if (venvMode === 'local') {
+							const venvPath = await createLocalVenv(context, workspaceFolder);
+							if (venvPath) {
+								await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder)
+									.update(ZEPHYR_WORKBENCH_VENV_PATH_SETTING_KEY, venvPath, vscode.ConfigurationTarget.WorkspaceFolder);
+							}
+						}
+						CreateZephyrAppPanel.currentPanel?.dispose();
+
+						vscode.window.showInformationMessage(`New Application '${workspaceFolder.name}' created !`);
+						requestAppRefresh();
+					}
+				});
+			});
 		})
 	);
 
@@ -2066,24 +2097,26 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			await addWorkspaceFolder(projectLoc);
+			await withAppRefreshBatch(async () => {
+				await addWorkspaceFolder(projectLoc);
 
-			let workspaceFolder = getWorkspaceFolder(projectLoc);
-			if (workspaceFolder && westWorkspace && zephyrBoard && zephyrSDK) {
-				await setDefaultProjectSettings(workspaceFolder, westWorkspace, zephyrBoard, zephyrSDK);
-				await createTasksJson(workspaceFolder);
-				await createExtensionsJson(workspaceFolder);
-				// Optionally create a local venv for the imported project
-				if (venvMode === 'local') {
-					const venvPath = await createLocalVenv(context, workspaceFolder);
-					if (venvPath) {
-						await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder)
-							.update(ZEPHYR_WORKBENCH_VENV_PATH_SETTING_KEY, venvPath, vscode.ConfigurationTarget.WorkspaceFolder);
+				let workspaceFolder = getWorkspaceFolder(projectLoc);
+				if (workspaceFolder && westWorkspace && zephyrBoard && zephyrSDK) {
+					await setDefaultProjectSettings(workspaceFolder, westWorkspace, zephyrBoard, zephyrSDK);
+					await createTasksJson(workspaceFolder);
+					await createExtensionsJson(workspaceFolder);
+					// Optionally create a local venv for the imported project
+					if (venvMode === 'local') {
+						const venvPath = await createLocalVenv(context, workspaceFolder);
+						if (venvPath) {
+							await vscode.workspace.getConfiguration(ZEPHYR_WORKBENCH_SETTING_SECTION_KEY, workspaceFolder)
+								.update(ZEPHYR_WORKBENCH_VENV_PATH_SETTING_KEY, venvPath, vscode.ConfigurationTarget.WorkspaceFolder);
+						}
 					}
+					vscode.window.showInformationMessage(`Importing Application '${workspaceFolder.name}' done`);
+					requestAppRefresh();
 				}
-				vscode.window.showInformationMessage(`Importing Application '${workspaceFolder.name}' done`);
-					zephyrAppProvider.refresh();
-			}
+			});
 		})
 	);
 
@@ -2194,7 +2227,7 @@ export function activate(context: vscode.ExtensionContext) {
 	/* Listeners on workspace changes */
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeWorkspaceFolders((event: vscode.WorkspaceFoldersChangeEvent) => {
-			zephyrAppProvider.refresh();
+			requestAppRefresh();
 			//zephyrModuleProvider.refresh();
 			westWorkspaceProvider.refresh();
 		})
@@ -2208,7 +2241,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (event) => {
 			if (event.affectsConfiguration('tasks')) {
-				zephyrAppProvider.refresh();
+				requestAppRefresh();
 			}
 
 			if (event.affectsConfiguration(ZEPHYR_WORKBENCH_LIST_SDKS_SETTING_KEY)) {
@@ -2224,7 +2257,7 @@ export function activate(context: vscode.ExtensionContext) {
 				event.affectsConfiguration(`${ZEPHYR_WORKBENCH_SETTING_SECTION_KEY}.${ZEPHYR_PROJECT_WEST_WORKSPACE_SETTING_KEY}`) ||
 				event.affectsConfiguration(`${ZEPHYR_WORKBENCH_SETTING_SECTION_KEY}.${ZEPHYR_PROJECT_SDK_SETTING_KEY}`) ||
 				event.affectsConfiguration(`${ZEPHYR_WORKBENCH_SETTING_SECTION_KEY}.build.configurations`)) {
-				zephyrAppProvider.refresh();
+				requestAppRefresh();
 			}
 		})
 	);

--- a/src/models/ZephyrProject.ts
+++ b/src/models/ZephyrProject.ts
@@ -121,11 +121,30 @@ export class ZephyrProject {
       return cachedValue; 
     }
 
+    const hasZephyrTaskFile = ZephyrProject.isZephyrProjectPath(projectPath);
+    if (hasZephyrTaskFile) {
+      ZephyrProject.zephyrProjectWorkspaceCache.set(projectPath, true);
+      return true;
+    }
+
     const westBuildTask = await findTask('West Build', folder);
-    const isZephyrProject = ZephyrProject.isZephyrProjectPath(projectPath) || !!(westBuildTask && westBuildTask.definition.type === ZephyrTaskProvider.ZephyrType);
+    const isZephyrProject = !!(westBuildTask && westBuildTask.definition.type === ZephyrTaskProvider.ZephyrType);
 
     ZephyrProject.zephyrProjectWorkspaceCache.set(projectPath, isZephyrProject);
     return isZephyrProject;
+  }
+
+  static async getZephyrProjectWorkspaceFolders(
+    folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? []
+  ): Promise<vscode.WorkspaceFolder[]> {
+    const results = await Promise.allSettled(
+      folders.map(async (folder) => {
+        const isProject = await ZephyrProject.isZephyrProjectWorkspaceFolder(folder);
+        return isProject ? folder : undefined;
+      })
+    );
+
+    return results.flatMap((result) => result.status === 'fulfilled' && result.value ? [result.value] : []);
   }
 
   static invalidateZephyrProjectWorkspaceFolder(projectPath: string) {

--- a/src/panels/DebugManagerPanel.ts
+++ b/src/panels/DebugManagerPanel.ts
@@ -408,12 +408,11 @@ export class DebugManagerPanel {
     async function loadApplications(webview: vscode.Webview) {
       let applicationsHTML = '';
       if(vscode.workspace.workspaceFolders) {
-        for(const workspaceFolder of vscode.workspace.workspaceFolders) {
+        const projectFolders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders);
+        for (const workspaceFolder of projectFolders) {
           try {
-            if(await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspaceFolder)) {
-              const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
-              applicationsHTML = applicationsHTML.concat(`<div class="dropdown-item" data-value="${appProject.sourceDir}" data-label="${appProject.folderName}">${appProject.folderName} <span class="description">${appProject.sourceDir}</span></div>`);
-            }
+            const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
+            applicationsHTML = applicationsHTML.concat(`<div class="dropdown-item" data-value="${appProject.sourceDir}" data-label="${appProject.folderName}">${appProject.folderName} <span class="description">${appProject.sourceDir}</span></div>`);
           } catch {}
         }
       }

--- a/src/panels/EclairManagerPanel.ts
+++ b/src/panels/EclairManagerPanel.ts
@@ -1192,12 +1192,9 @@ async function load_applications(): Promise<ZephyrAppProject[]> {
   }
 
   let applications: ZephyrAppProject[] = [];
-  for (const workspace_folder of vscode.workspace.workspaceFolders) {
+  const project_folders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders);
+  for (const workspace_folder of project_folders) {
     try {
-      if (!await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspace_folder)) {
-        continue;
-      }
-
       const app_project = new ZephyrAppProject(workspace_folder, workspace_folder.uri.fsPath);
       applications.push(app_project);
     } catch {

--- a/src/panels/RunManagerPanel.ts
+++ b/src/panels/RunManagerPanel.ts
@@ -79,11 +79,10 @@ export class RunManagerPanel {
     let applicationsHTML: string = '';
 
     if(vscode.workspace.workspaceFolders) {
-      for(let workspaceFolder of vscode.workspace.workspaceFolders) {
-        if(await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspaceFolder)) {
-          const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
-          applicationsHTML = applicationsHTML.concat(`<div class="dropdown-item" data-value="${appProject.sourceDir}" data-label="${appProject.folderName}">${appProject.folderName} <span class="description">${appProject.sourceDir}</span></div>`);
-        }
+      const projectFolders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders);
+      for (const workspaceFolder of projectFolders) {
+        const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
+        applicationsHTML = applicationsHTML.concat(`<div class="dropdown-item" data-value="${appProject.sourceDir}" data-label="${appProject.folderName}">${appProject.folderName} <span class="description">${appProject.sourceDir}</span></div>`);
       }
     }
 
@@ -356,5 +355,4 @@ export class RunManagerPanel {
     }
   }  
 }
-
 

--- a/src/providers/ZephyrApplicationProvider.ts
+++ b/src/providers/ZephyrApplicationProvider.ts
@@ -23,12 +23,11 @@ export class ZephyrApplicationDataProvider implements vscode.TreeDataProvider<vs
 		const items: vscode.TreeItem[] = [];
     if(element === undefined) {
       if(vscode.workspace.workspaceFolders) {
-        for(let workspaceFolder of vscode.workspace.workspaceFolders) {
-          if(await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspaceFolder)) {
-            const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
-            const item =  new ZephyrApplicationTreeItem(appProject, vscode.TreeItemCollapsibleState.Collapsed);
-            items.push(item);
-          }
+        const projectFolders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders);
+        for (const workspaceFolder of projectFolders) {
+          const appProject = new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
+          const item =  new ZephyrApplicationTreeItem(appProject, vscode.TreeItemCollapsibleState.Collapsed);
+          items.push(item);
         }
         return Promise.resolve(items);
       }

--- a/src/quicksteps/pickApplicationQuickStep.ts
+++ b/src/quicksteps/pickApplicationQuickStep.ts
@@ -6,10 +6,9 @@ export async function pickApplicationQuickStep(context: ExtensionContext): Promi
   const applicationItems: QuickPickItem[] = [];
   
   if(vscode.workspace.workspaceFolders) {
-    for(let workspaceFolder of vscode.workspace.workspaceFolders) {
-      if(await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspaceFolder)) {
-        applicationItems.push({ label: workspaceFolder.name, description: workspaceFolder.uri.fsPath});
-      }
+    const projectFolders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders);
+    for (const workspaceFolder of projectFolders) {
+      applicationItems.push({ label: workspaceFolder.name, description: workspaceFolder.uri.fsPath});
     }
   }
   

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,6 +16,8 @@ import { getBoardsDirectories, westTmpBuildCmakeOnlyCommand } from '../commands/
 import { checkOrCreateTask, ZephyrTaskProvider } from '../providers/ZephyrTaskProvider';
 import { ZephyrProjectBuildConfiguration } from '../models/ZephyrProjectBuildConfiguration';
 
+let zephyrTasksFetchPromise: Promise<vscode.Task[]> | undefined;
+
 export function msleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -407,11 +409,10 @@ export function findIarEntry(iarPath: string): IARToolchain | undefined {
 
 
 export async function getZephyrProject(projectPath: string): Promise<ZephyrProject> {
-  for (let workspaceFolder of vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]) {
-    if (await ZephyrAppProject.isZephyrProjectWorkspaceFolder(workspaceFolder)) {
-      if (workspaceFolder.uri.fsPath === projectPath) {
-        return new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
-      }
+  const projectFolders = await ZephyrAppProject.getZephyrProjectWorkspaceFolders(vscode.workspace.workspaceFolders as vscode.WorkspaceFolder[]);
+  for (const workspaceFolder of projectFolders) {
+    if (workspaceFolder.uri.fsPath === projectPath) {
+      return new ZephyrAppProject(workspaceFolder, workspaceFolder.uri.fsPath);
     }
   }
   vscode.window.showInformationMessage("This is not a Zephyr application " +`${projectPath}`);
@@ -500,8 +501,23 @@ async function fetchTasksFromWorkspaceFolder(workspaceFolder: vscode.WorkspaceFo
   }
 }
 
+async function getZephyrWorkbenchTasks(): Promise<vscode.Task[]> {
+  if (!zephyrTasksFetchPromise) {
+    const fetchPromise = Promise.resolve(vscode.tasks.fetchTasks({ type: 'zephyr-workbench' }));
+    zephyrTasksFetchPromise = fetchPromise;
+
+    fetchPromise.finally(() => {
+      if (zephyrTasksFetchPromise === fetchPromise) {
+        zephyrTasksFetchPromise = undefined;
+      }
+    });
+  }
+
+  return zephyrTasksFetchPromise;
+}
+
 export async function findTask(taskLabel: string, workspaceFolder: vscode.WorkspaceFolder): Promise<vscode.Task | undefined> {
-  const tasks = await vscode.tasks.fetchTasks({ type: 'zephyr-workbench' });
+  const tasks = await getZephyrWorkbenchTasks();
   return tasks.find(task => {
     const folder = task.scope as vscode.WorkspaceFolder;
     return folder && folder.uri.toString() === workspaceFolder.uri.toString() && task.name === taskLabel;
@@ -511,7 +527,7 @@ export async function findTask(taskLabel: string, workspaceFolder: vscode.Worksp
 export async function findOrCreateTask(taskLabel: string, workspaceFolder: vscode.WorkspaceFolder): Promise<vscode.Task | undefined> {
   const taskExists = await checkOrCreateTask(workspaceFolder, taskLabel);
   if (taskExists) {
-    const tasks = await vscode.tasks.fetchTasks({ type: 'zephyr-workbench' });
+    const tasks = await getZephyrWorkbenchTasks();
     return tasks.find(task => {
       const folder = task.scope as vscode.WorkspaceFolder;
       return folder && folder.uri.toString() === workspaceFolder.uri.toString() && task.name === taskLabel;
@@ -531,7 +547,7 @@ export async function findOrCreateTask(taskLabel: string, workspaceFolder: vscod
 export async function findConfigTask(taskLabel: string, project: ZephyrProject, configName: string): Promise<vscode.Task | undefined> {
   const taskExists = await checkOrCreateTask(project.workspaceFolder, taskLabel);
   if (taskExists) {
-    const tasks = await vscode.tasks.fetchTasks({ type: 'zephyr-workbench' });
+    const tasks = await getZephyrWorkbenchTasks();
     const task = tasks.find(task => {
       const folder = task.scope as vscode.WorkspaceFolder;
       return folder && folder.uri.toString() === project.workspaceFolder.uri.toString() && task.name === taskLabel;


### PR DESCRIPTION
Improve app discovery refresh performance
- parallelize workspace folder checks for Zephyr app detection
- dedupe in-flight task fetches during app discovery
- short-circuit task-file detection before task API calls