### PR TITLE
Centralize debug tool version probing and runner detection

### DIFF
--- a/scripts/runners/debug-tools.yml
+++ b/scripts/runners/debug-tools.yml
@@ -5,7 +5,10 @@
 # Common tool fields: `type` = `debug_server` | `flasher` | `driver`,
 # `os.<platform>` = download info / `true` / `false`, `root` = admin install,
 # `no_edit` = path editing disabled in the UI so "EDIT" button will be hidden,
-# `auto-detect` = env.yml auto-detect glob paths, `explicit-detect` = panel-only install roots.
+# `auto-detect` = env.yml auto-detect glob paths, `explicit-detect` = exact panel detection paths,
+# `version` = reference/install version used for update comparisons only,
+# `version-command` / `version-file` / `version-regex` = installed-version probe metadata.
+# `version-command` and `version-file` can be a string or OS-specific map.
 
 #--- use versionning, this is needed to manage env.yml, mainly for auto-detect ---
 version: 2
@@ -50,18 +53,18 @@ debug_tools:
 - tool: openocd-zephyr
   alias: openocd
   name: OpenOCD Zephyr
-  version: 0.12.0
+  version: 0.12.0-01025-g662bf274f
   website: https://github.com/zephyrproject-rtos/openocd
   type: debug_server
   group: Openocds/Zephyr
   install_dir: openocds/openocd-zephyr
   explicit-detect:
     windows:
-      - "${zi_base_dir}/tools/openocds/openocd-zephyr"
+      - "${zi_base_dir}/tools/openocds/openocd-zephyr/bin"
     linux:
-      - "${zi_base_dir}/tools/openocds/openocd-zephyr"
+      - "${zi_base_dir}/tools/openocds/openocd-zephyr/bin"
     darwin:
-      - "${zi_base_dir}/tools/openocds/openocd-zephyr"
+      - "${zi_base_dir}/tools/openocds/openocd-zephyr/bin"
   root: false
   os:
     windows:
@@ -76,18 +79,18 @@ debug_tools:
 - tool: openocd-esp32
   alias: openocd
   name: OpenOCD ESP32
-  version: 0.12.0
+  version: v0.13.0-esp32-20251215
   website: https://github.com/espressif/openocd-esp32/releases
   type: debug_server
   group: Openocds/ESP32
   install_dir: openocds/openocd-esp32
   explicit-detect:
     windows:
-      - "${zi_base_dir}/tools/openocds/openocd-esp32"
+      - "${zi_base_dir}/tools/openocds/openocd-esp32/bin"
     linux:
-      - "${zi_base_dir}/tools/openocds/openocd-esp32"
+      - "${zi_base_dir}/tools/openocds/openocd-esp32/bin"
     darwin:
-      - "${zi_base_dir}/tools/openocds/openocd-esp32"
+      - "${zi_base_dir}/tools/openocds/openocd-esp32/bin"
   root: false
   os:
     windows:
@@ -109,11 +112,11 @@ debug_tools:
   install_dir: openocds/openocd-xpack
   explicit-detect:
     windows:
-      - "${zi_base_dir}/tools/openocds/openocd-xpack"
+      - "${zi_base_dir}/tools/openocds/openocd-xpack/bin"
     linux:
-      - "${zi_base_dir}/tools/openocds/openocd-xpack"
+      - "${zi_base_dir}/tools/openocds/openocd-xpack/bin"
     darwin:
-      - "${zi_base_dir}/tools/openocds/openocd-xpack"
+      - "${zi_base_dir}/tools/openocds/openocd-xpack/bin"
   root: false
   os:
     windows:
@@ -128,22 +131,22 @@ debug_tools:
 - tool: openocd-modustoolbox
   alias: openocd
   name: OpenOCD Infineon
-  version: 0.12.0
+  version: 0.12.0+dev-5.12.0.4170
   website: https://softwaretools.infineon.com/tools/com.ifx.tb.tool.modustoolboxprogtools
   vendor: Infineon
   type: debug_server
   group: Openocds/Infineon
   root: true
   no_edit: true
-  # Used by the runners panel to locate the install root and derive the bin path for env.yml.
-  # ModusToolbox is special because its install root is outside the internal install tree.
+  # Explicitly points to the command dir used by the panel and env.yml.
+  # ModusToolbox is special because its install path is outside the internal install tree.
   explicit-detect:
     windows:
-      - "C:/Infineon/Tools/ModusToolboxProgtools-*/openocd"
+      - "C:/Infineon/Tools/ModusToolboxProgtools-*/openocd/bin"
     linux:
-      - "/opt/Tools/ModusToolboxProgtools-*/openocd"
+      - "/opt/Tools/ModusToolboxProgtools-*/openocd/bin"
     darwin:
-      - "/Applications/ModusToolboxProgtools-*/openocd"
+      - "/Applications/ModusToolboxProgtools-*/openocd/bin"
   os:
     windows:
       source: https://softwaretools-hosting.infineon.com/api/packages/com.ifx.tb.tool.modustoolboxprogtools/versions/1.7.0.1727/artifacts/ModusToolboxProgtools_1.7.0.1727.exe/download
@@ -157,19 +160,30 @@ debug_tools:
 - tool: openocd-custom
   alias: openocd
   name: OpenOCD Custom 
-  version: 0.12.0
+  version: IGNORE
   website: https://openocd.org/
   type: debug_server
   group: Openocds
-  install_dir: openocds/openocd-custom
   root: false
+  explicit-detect:
+    windows:
+      - ""
+    linux:
+      - ""
+    darwin:
+      - ""
   os:
     windows: false
     linux: false
     darwin: false
 - tool: jlink
   name: J-Link Software
-  version: 8.78
+  version: 9.32
+  version-command:
+    windows: JLinkGDBServerCL.exe --version
+    linux: JLinkGDBServerCL --version
+    darwin: JLinkGDBServerCL --version
+  version-regex: '/J-Link GDB Server V([\d.]+[a-z]?)/i'
   website: https://www.segger.com/downloads/jlink/
   vendor: Segger
   type: debug_server
@@ -188,6 +202,11 @@ debug_tools:
 - tool: stm32cubeprogrammer
   name: STM32CubeProgrammer
   version: 2.17.0 
+  version-command:
+    windows: STM32_Programmer_CLI.exe --version
+    linux: STM32_Programmer_CLI --version
+    darwin: STM32_Programmer_CLI --version
+  version-regex: '/STM32CubeProgrammer version: ([\d.]+)/'
   website: https://www.st.com/en/development-tools/stm32cubeprog.html
   vendor: ST
   type: flasher
@@ -213,6 +232,11 @@ debug_tools:
 - tool: linkserver
   name: NXP LinkServer for Microcontrollers
   version: 24.9.75
+  version-command:
+    windows: LinkServer.exe --version
+    linux: LinkServer --version
+    darwin: LinkServer --version
+  version-regex: '/\bLinkServer\s+v?([\d.]+)/i'
   website: https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/linkserver-for-microcontrollers:LINKERSERVER
   vendor: NXP
   type: debug_server
@@ -229,6 +253,11 @@ debug_tools:
 - tool: nrfjprog
   name: nRF Command Line Tools
   version: 10.24.2
+  version-command:
+    windows: nrfjprog.exe --version
+    linux: nrfjprog --version
+    darwin: nrfjprog --version
+  version-regex: '/nrfjprog version:\s*([\d.]+)/i'
   website: https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download
   vendor: Nordic Semiconductor
   type: flasher
@@ -247,6 +276,11 @@ debug_tools:
 - tool: nrfutil
   name: nRF Util
   version: 8.1.1
+  version-command:
+    windows: nrfutil.exe --version
+    linux: nrfutil --version
+    darwin: nrfutil --version
+  version-regex: '/nrfutil(?: version)? ([\d.]+)/i'
   website: https://www.nordicsemi.com/Products/Development-tools/nRF-Util
   vendor: Nordic Semiconductor
   type: flasher
@@ -264,7 +298,12 @@ debug_tools:
       sha256: 726c8e6e4cb5e0811f342620f88472351b1203f2af8e27b744e653f34a08deb4
 - tool: simplicity_commander
   name: Silabs Simplicity Commander
-  version: 1v20p5b1945
+  version: 1v23p1b1971
+  version-command:
+    windows: commander-cli.exe --version
+    linux: commander-cli --version
+    darwin: commander-cli --version
+  version-regex: '/Simplicity Commander\s+([A-Za-z0-9._-]+)/i'
   website: https://www.silabs.com/software-and-tools/simplicity-studio/simplicity-commander
   vendor: Silicon Labs
   type: flasher
@@ -291,6 +330,11 @@ debug_tools:
 - tool: pyocd
   name: pyOCD
   version: 0.36.0
+  version-command:
+    windows: pyocd --version
+    linux: pyocd --version
+    darwin: pyocd --version
+  version-regex: '/\b(\d+(?:\.\d+)+)\b/'
   website: https://pyocd.io/
   type: debug_server
   group: Common
@@ -301,7 +345,14 @@ debug_tools:
     darwin: true
 - tool: cp210x
   name: USB to UART Bridge VCP CP210x Universal Drivers 
-  version: 11.4.0 
+  version: 11.5.0.417
+  explicit-detect:
+    windows:
+      - "C:/Windows/System32/DriverStore/FileRepository/silabser.inf_*/silabser.inf"
+  version-file:
+    windows: "C:/Windows/System32/DriverStore/FileRepository/silabser.inf_*/silabser.inf"
+  version-regex:
+    windows: '/DriverVer\s*=\s*[^,]+,([\d.]+)/i'
   website: https://www.silabs.com/developer-tools/usb-to-uart-bridge-vcp-drivers
   vendor: Silicon Labs
   type: driver
@@ -332,19 +383,19 @@ debug_tools:
 packs:
 - pack: stm32
   name: STM32
-  tools: [openocd, stm32cubeprogrammer, jlink, udev-rules]
+  tools: [openocd-zephyr, stm32cubeprogrammer, jlink, udev-rules]
 - pack: nxp
   name: NXP
   tools: [linkserver, jlink]
 - pack: nordic
   name: Nordic
-  tools: [jlink, nrfutil, nrfjprog]
+  tools: [nrfutil, nrfjprog, jlink]
 - pack: silabs
   name: Silabs
   tools: [simplicity_commander, cp210x, jlink]
 - pack: esp32
   name: ESP32
-  tools: [cp210x]
+  tools: [openocd-esp32, cp210x]
 - pack: infineon
   name: Infineon
   tools: [openocd-modustoolbox]
@@ -352,4 +403,9 @@ packs:
 aliases:
 - alias: openocd
   name: OpenOCD
+  version-command:
+    windows: openocd.exe --version
+    linux: openocd --version
+    darwin: openocd --version
+  version-regex: '/Open On-Chip Debugger ([^\s]+)/'
   default: openocd-zephyr 

--- a/src/debug/runners/JLink.ts
+++ b/src/debug/runners/JLink.ts
@@ -9,12 +9,8 @@ export class JLink extends WestRunner {
   get executable(): string | undefined {
     const exec = super.executable;
     if(!exec) {
-      return process.platform === 'win32' ? 'JLinkGDBServerCL' : 'JLinkGDBServerCLExe';
+      return process.platform === 'win32' ? 'JLinkGDBServerCL.exe' : 'JLinkGDBServerCLExe';
     }
-  }
-
-  get versionRegex(): any | undefined {
-    return /J-Link GDB Server V([\d.]+[a-z]?)/i;
   }
 
   loadArgs(args: string | undefined) {

--- a/src/debug/runners/Linkserver.ts
+++ b/src/debug/runners/Linkserver.ts
@@ -1,9 +1,8 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for NXP LinkServer.
- * Simplified version — assumes the LinkServer CLI tool is available in the system PATH.
+ * Simplified version - assumes the LinkServer CLI tool is available in the system PATH.
  * Used for flashing and debugging NXP MCUs.
  */
 export class Linkserver extends WestRunner {
@@ -14,19 +13,11 @@ export class Linkserver extends WestRunner {
 
   /**
    * Returns the executable name based on the current platform.
-   * On Windows → LinkServer.exe
-   * On Linux/macOS → LinkServer
+   * On Windows: LinkServer.exe
+   * On Linux/macOS: LinkServer
    */
   get executable(): string {
     return process.platform === 'win32' ? 'LinkServer.exe' : 'LinkServer';
-  }
-
-  /**
-   * Regex to capture the version number from CLI output.
-   * Example: "LinkServer v2.7.0" → captures "2.7.0"
-   */
-  get versionRegex(): RegExp {
-    return /v([\d.]+)/;
   }
 
   /**
@@ -46,20 +37,5 @@ export class Linkserver extends WestRunner {
    */
   get autoArgs(): string {
     return super.autoArgs;
-  }
-
-  /**
-   * Detect if LinkServer is installed and accessible from the PATH.
-   * Runs "<executable> --version" and returns true if it executes successfully.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`;
-
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any) => {
-        // If no error → LinkServer was found and executed correctly
-        resolve(!error);
-      });
-    });
   }
 }

--- a/src/debug/runners/Nrfjprog.ts
+++ b/src/debug/runners/Nrfjprog.ts
@@ -1,37 +1,28 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for Nordic nrfjprog command-line utility.
- * Simplified version — assumes nrfjprog is available in the system PATH.
+ * Simplified version - assumes nrfjprog is available in the system PATH.
  * Used for flashing and programming Nordic devices (via J-Link).
  */
 export class Nrfjprog extends WestRunner {
   name = 'nrfjprog';
   label = 'nRFjprog';
   types = [RunnerType.FLASH, RunnerType.DEBUG]; // Supports both flashing and debugging
-  serverStartedPattern = ''; // nrfjprog doesn’t start a GDB server
+  serverStartedPattern = ''; // nrfjprog doesn't start a GDB server
 
   /**
    * Returns the executable name depending on the OS.
-   * On Windows → nrfjprog.exe
-   * On Linux/macOS → nrfjprog
+   * On Windows: nrfjprog.exe
+   * On Linux/macOS: nrfjprog
    */
   get executable(): string {
     return process.platform === 'win32' ? 'nrfjprog.exe' : 'nrfjprog';
   }
 
   /**
-   * Regex to capture the nrfjprog version number from CLI output.
-   * Example: "nrfjprog version: 10.24.2 external"
-   */
-  get versionRegex(): RegExp {
-    return /nrfjprog version:\s*([\d.]+)/i;
-  }
-
-  /**
    * Loads user-provided arguments, if any.
-   * (No search for system locations — just pass through.)
+   * (No search for system locations - just pass through.)
    */
   loadArgs(args: string | undefined) {
     super.loadArgs(args);
@@ -46,22 +37,5 @@ export class Nrfjprog extends WestRunner {
    */
   get autoArgs(): string {
     return super.autoArgs;
-  }
-
-  /**
-   * Detects whether nrfjprog is installed and accessible via PATH.
-   * Executes "nrfjprog --version" and checks for valid output.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`;
-
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any, stdout: string, stderr: string) => {
-        // Combine stdout and stderr since version info may appear on either
-        const output = `${stdout}\n${stderr}`;
-        const found = this.versionRegex.test(output);
-        resolve(found);
-      });
-    });
   }
 }

--- a/src/debug/runners/Nrfutil.ts
+++ b/src/debug/runners/Nrfutil.ts
@@ -1,37 +1,28 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for Nordic nrfutil CLI tool.
- * Simplified version — assumes nrfutil is available in the system PATH.
+ * Simplified version - assumes nrfutil is available in the system PATH.
  * Used for flashing and DFU operations on Nordic devices.
  */
 export class Nrfutil extends WestRunner {
   name = 'nrfutil';
   label = 'nRF Util';
   types = [ RunnerType.FLASH ]; // Only flashing / DFU (no debugging)
-  serverStartedPattern = ''; // nrfutil doesn’t launch a persistent GDB server
+  serverStartedPattern = ''; // nrfutil doesn't launch a persistent GDB server
 
   /**
    * Returns the executable name based on the platform.
-   * On Windows → nrfutil.exe
-   * On Linux/macOS → nrfutil
+   * On Windows: nrfutil.exe
+   * On Linux/macOS: nrfutil
    */
   get executable(): string {
     return process.platform === 'win32' ? 'nrfutil.exe' : 'nrfutil';
   }
 
   /**
-   * Regex to extract the version number from CLI output.
-   * Example output: "nrfutil version 6.1.9"
-   */
-  get versionRegex(): RegExp {
-    return /nrfutil(?: version)? ([\d.]+)/i;
-  }
-
-  /**
    * Loads user-provided arguments (if any).
-   * No system path or settings lookup — just passes them through.
+   * No system path or settings lookup - just passes them through.
    */
   loadArgs(args: string | undefined) {
     super.loadArgs(args);
@@ -46,20 +37,5 @@ export class Nrfutil extends WestRunner {
    */
   get autoArgs(): string {
     return super.autoArgs;
-  }
-
-  /**
-   * Detects if nrfutil is installed and available in PATH.
-   * Runs "nrfutil --version" and checks output.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`;
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any, stdout: string, stderr: string) => {
-        const output = `${stdout}\n${stderr}`;
-        const found = this.versionRegex.test(output);
-        resolve(found);
-      });
-    });
   }
 }

--- a/src/debug/runners/Openocd.ts
+++ b/src/debug/runners/Openocd.ts
@@ -1,9 +1,8 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for OpenOCD (Open On-Chip Debugger).
- * Simplified version — assumes `openocd` is available in the system PATH.
+ * Simplified version - assumes `openocd` is available in the system PATH.
  * Used for flashing and debugging ARM-based targets.
  */
 export class Openocd extends WestRunner {
@@ -14,19 +13,11 @@ export class Openocd extends WestRunner {
 
   /**
    * Returns the executable name based on the current platform.
-   * On Windows → openocd.exe
-   * On Linux/macOS → openocd
+   * On Windows: openocd.exe
+   * On Linux/macOS: openocd
    */
   get executable(): string {
     return process.platform === 'win32' ? 'openocd.exe' : 'openocd';
-  }
-
-  /**
-   * Regex to capture the version number from CLI output.
-   * Example: "Open On-Chip Debugger 0.12.0" → captures "0.12.0"
-   */
-  get versionRegex(): RegExp {
-    return /Open On-Chip Debugger ([\d.]+)/;
   }
 
   /**
@@ -49,20 +40,6 @@ export class Openocd extends WestRunner {
     cmdArgs += ' --config openocd.cfg';
     cmdArgs += ' --config ${workspaceFolder}/build/.debug/gdb.cfg';
     return cmdArgs;
-  }
-
-  /**
-   * Detects if OpenOCD is installed and available in PATH.
-   * Runs "openocd --version" and checks if it executes successfully.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`; // Redirect stderr since OpenOCD prints version to stderr
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any) => {
-        // If no error, OpenOCD is available
-        resolve(!error);
-      });
-    });
   }
 
   /**

--- a/src/debug/runners/PyOCD.ts
+++ b/src/debug/runners/PyOCD.ts
@@ -13,10 +13,6 @@ export class PyOCD extends WestRunner {
     }
   }
 
-  get versionRegex(): any | undefined {
-    return /([\d.]+)/;
-  }
-
   loadArgs(args: string | undefined) {
     super.loadArgs(args);
 

--- a/src/debug/runners/STM32CubeProgrammer.ts
+++ b/src/debug/runners/STM32CubeProgrammer.ts
@@ -1,9 +1,8 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for STM32CubeProgrammer.
- * Simplified version — assumes the CLI tool is available in the system PATH.
+ * Simplified version - assumes the CLI tool is available in the system PATH.
  */
 export class STM32CubeProgrammer extends WestRunner {
   name = 'stm32cubeprogrammer';
@@ -13,8 +12,8 @@ export class STM32CubeProgrammer extends WestRunner {
 
   /**
    * Returns the executable name based on the current platform.
-   * On Windows → STM32_Programmer_CLI.exe
-   * On Linux/macOS → STM32_Programmer_CLI
+   * On Windows: STM32_Programmer_CLI.exe
+   * On Linux/macOS: STM32_Programmer_CLI
    */
   get executable(): string {
     return process.platform === 'win32'
@@ -23,14 +22,7 @@ export class STM32CubeProgrammer extends WestRunner {
   }
 
   /**
-   * Regex to capture the version number from CLI output.
-   */
-  get versionRegex(): RegExp {
-    return /STM32CubeProgrammer version: ([\d.]+)/;
-  }
-
-  /**
-   * Load user arguments if provided — no extra search logic.
+   * Load user arguments if provided - no extra search logic.
    */
   loadArgs(args: string | undefined) {
     super.loadArgs(args);
@@ -41,24 +33,9 @@ export class STM32CubeProgrammer extends WestRunner {
 
   /**
    * Auto arguments for this runner.
-   * Just inherits from the base runner — no extra args needed.
+   * Just inherits from the base runner - no extra args needed.
    */
   get autoArgs(): string {
     return super.autoArgs;
-  }
-
-  /**
-   * Detect if STM32CubeProgrammer is available in PATH.
-   * Simply runs `<executable> --version` and checks if it executes successfully.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`;
-
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any) => {
-        // If command executes without error, the tool is available
-        resolve(!error);
-      });
-    });
   }
 }

--- a/src/debug/runners/SimplicityCommander.ts
+++ b/src/debug/runners/SimplicityCommander.ts
@@ -1,5 +1,4 @@
 import { RunnerType, WestRunner } from "./WestRunner";
-import { execCommandWithEnv } from "../../utils/execUtils";
 
 /**
  * Runner for Silicon Labs Simplicity Commander CLI tool.
@@ -13,21 +12,11 @@ export class SimplicityCommander extends WestRunner {
 
   /**
    * Returns the executable name based on the platform.
-   * On Windows → commander-cli.exe
-   * On Linux/macOS → commander-cli
+   * On Windows: commander-cli.exe
+   * On Linux/macOS: commander-cli
    */
   get executable(): string {
     return process.platform === 'win32' ? 'commander-cli.exe' : 'commander-cli';
-  }
-
-  /**
-   * Regex to extract the version number from CLI output.
-   * Example output:
-   *   Simplicity Commander 1v20p5b1945
-   *   JLink DLL version: 8.44
-   */
-  get versionRegex(): RegExp {
-    return /Simplicity Commander\s+([A-Za-z0-9._-]+)/i;
   }
 
   /**
@@ -47,39 +36,5 @@ export class SimplicityCommander extends WestRunner {
    */
   get autoArgs(): string {
     return super.autoArgs;
-  }
-
-  /**
-   * Detects if commander-cli is installed and available in PATH or tools directory.
-   * Runs "commander-cli --version" and checks output.
-   */
-  async detect(): Promise<boolean> {
-    const cmd = `${this.executable} --version`;
-    return new Promise<boolean>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any, stdout: string, stderr: string) => {
-        const output = `${stdout}\n${stderr}`;
-        const found = this.versionRegex.test(output);
-        resolve(found);
-      });
-    });
-  }
-
-  /**
-   * Retrieves the version string by running the CLI and parsing the output.
-   * Example: returns "1v20p5b1945".
-   */
-  async getVersion(): Promise<string | undefined> {
-    const cmd = `${this.executable} --version`;
-    return new Promise<string | undefined>((resolve) => {
-      execCommandWithEnv(cmd, undefined, (error: any, stdout: string, stderr: string) => {
-        const output = `${stdout}\n${stderr}`;
-        const match = this.versionRegex.exec(output);
-        if (match && match[1]) {
-          resolve(match[1].trim());
-        } else {
-          resolve(undefined);
-        }
-      });
-    });
   }
 }

--- a/src/debug/runners/WestRunner.ts
+++ b/src/debug/runners/WestRunner.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import path from "path";
 import { ZEPHYR_WORKBENCH_SETTING_SECTION_KEY } from "../../constants";
 import { execCommandWithEnv } from '../../utils/execUtils';
+import { detectRunnerVersion } from '../../utils/debugToolVersionUtils';
 import { formatWindowsPath } from '../../utils/utils';
 
 export const ZEPHYR_WORKBENCH_DEBUG_PATH_SETTING_KEY = 'pathExec';
@@ -116,40 +117,9 @@ export class WestRunner {
   }
 
   async detectVersion(): Promise<string | undefined> {
-    if(!this.versionRegex) {
-      return undefined;
-    }
-    
-    let execPath = '';
-    if(this.serverPath) {
-      execPath = this.serverPath;
-    } else if(this.executable) {
-      execPath = this.executable;
-    }
-
-    if(execPath.includes(' ')) {
-      execPath=`"${execPath}"`;
-    }
-
-    let versionCmd = `${execPath} --version`;
-    return new Promise<string | undefined>((resolve) => {
-      execCommandWithEnv(versionCmd, undefined, (error: any, stdout: string, stderr: string) => {
-        if (error) {
-          resolve(undefined);
-          return;
-        }
-
-        // Merge both outputs, since some tools (e.g., OpenOCD) print version info to stderr
-        const output = `${stdout}\n${stderr}`;
-
-        const match = output.match(this.versionRegex);
-        if (match) {
-          resolve(match[1]);
-        } else {
-          resolve(undefined);
-        }
-      });
-    });
+    const execPath = this.serverPath || this.executable;
+    const normalizedExecPath = execPath?.replace(/^"(.*)"$/, '$1');
+    return detectRunnerVersion(this.name, normalizedExecPath);
   }
 
   get versionRegex(): any | undefined {

--- a/src/panels/DebugToolsPanel.ts
+++ b/src/panels/DebugToolsPanel.ts
@@ -2,19 +2,23 @@ import * as vscode from "vscode";
 import fs from "fs";
 import yaml from 'yaml';
 import path from "path";
-import { execSync } from "child_process";
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import { getRunner } from "../utils/debugUtils";
 import {
-  findDetectedToolRoot,
   getDetectPlatform,
   getToolCommandDir,
 } from "../utils/debugToolPathUtils";
+import {
+  DebugToolEntry,
+  DebugToolAliasEntry,
+  isIgnoredReferenceVersion,
+  probeDebugToolVersion,
+} from "../utils/debugToolVersionUtils";
 import { getInternalDirRealPath } from "../utils/utils";
 import { formatYml } from "../utilities/formatYml";
 import { setExtraPath as setEnvExtraPath, removeExtraPath as removeEnvExtraPath } from "../utils/envYamlUtils";
-import { Aliases, Tools } from "../interface/interfaceDebugTools";
+import { Aliases } from "../interface/interfaceDebugTools";
 
 export class DebugToolsPanel {
 
@@ -70,114 +74,116 @@ export class DebugToolsPanel {
     }, null, this._disposables);
   }
 
-  private async loadVersions() {
-    const versionPromises = this.data.debug_tools.map(async (tool: any) => {
-      if (tool.alias) {
-        const alias = tool.alias;
-        const installed = this.isOpenocdVariantInstalled(tool.tool);
-        const status = installed ? 'Installed' : 'Not installed';
-        this._panel.webview.postMessage({
-          command: "detect-done",
-          tool: tool.tool,
-          version: "",
-          status,
-        });
+  private getToolExecutableName(tool: any): string | undefined {
+    return this.getExecutableName(tool.alias || tool.tool);
+  }
 
-        if (this.getDefaultToolForAlias(alias) === tool.tool) {
-          if (installed) {
-            await this.ensureOpenocdAliasEntry(alias, tool.tool);
-          }
-          this._panel.webview.postMessage({
-            command: "detect-done",
-            tool: alias,
-            version: installed ? (tool.version || "") : "",
-            status,
-          });
-        }
-        return;
-      }
+  private getExecutableName(toolId: string): string | undefined {
+    return getRunner(toolId)?.executable;
+  }
 
-      // For alias groups (e.g. OpenOCD variants), detect only the configured default tool.
-      if (tool.alias) {
-        const defaultTool = this.getDefaultToolForAlias(tool.alias);
-        if (defaultTool && tool.tool !== defaultTool) {
-          this._panel.webview.postMessage({
-            command: "detect-done",
-            tool: tool.tool,
-            version: tool.version || "",
-            status: "Not installed",
-          });
-          return;
-        }
-      }
+  private getSelectedToolForAlias(alias: string): DebugToolEntry | undefined {
+    const selectedToolId = this.getDefaultToolForAlias(alias);
+    return this.data.debug_tools.find((tool: DebugToolEntry) => tool.tool === selectedToolId);
+  }
 
-      // Use alias if present, otherwise use tool
-      const runnerAlias = tool.alias || tool.tool;
+  private getAliasProbeTool(alias: string): DebugToolEntry | undefined {
+    const aliasEntry = this.data.aliases?.find((entry: DebugToolAliasEntry) => entry.alias === alias);
+    if (!aliasEntry) {
+      return undefined;
+    }
 
-      const runner = getRunner(runnerAlias);
-      
-      if (!runner) {
-        // Unknown runner -> consider not installed
-        this._panel.webview.postMessage({
-          command: "detect-done",
-          tool: tool.tool,
-          version: tool.version || "",
-          status: "Not installed",
-        });
-        return;
-      }
+    const selectedTool = this.getSelectedToolForAlias(alias);
 
-      runner.loadArgs(undefined);
-      try {
-        const installedVersion = await runner.detectVersion();
-        const actualVersion = tool.version;
-        const hasDifferentVersion = this.hasNewVersionByEnv(tool.tool, actualVersion);
-        const status = installedVersion
-          ? (hasDifferentVersion ? "New Version Available" : "Installed")
-          : "Not installed";
-        let reportedVersion = installedVersion || actualVersion || "";
+    return {
+      tool: alias,
+      version: selectedTool?.version,
+      ['version-command']: aliasEntry['version-command'],
+      ['version-file']: aliasEntry['version-file'],
+      ['version-regex']: aliasEntry['version-regex'],
+    };
+  }
 
-        if (status === "Not installed") {
-          reportedVersion = "";
-        }
-
-        if (installedVersion) {
-          tool.found = hasDifferentVersion ? "New Version Available" : "Installed";
-        }
-
-        // Update UI immediately after each finishes
-        this._panel.webview.postMessage({
-          command: "detect-done",
-          tool: tool.tool,
-          version: reportedVersion,
-          status,
-        });
-        if (tool.alias && this.getDefaultToolForAlias(tool.alias) === tool.tool) {
-          this._panel.webview.postMessage({
-            command: "detect-done",
-            tool: tool.alias,
-            version: reportedVersion,
-            status,
-          });
-        }
-      } catch (err) {
-        console.warn(`Version check failed for ${tool.tool}:`, err);
-        this._panel.webview.postMessage({
-          command: "detect-done",
-          tool: tool.tool,
-          version: tool.version || "",
-          status: "Not installed",
-        });
-        if (tool.alias && this.getDefaultToolForAlias(tool.alias) === tool.tool) {
-          this._panel.webview.postMessage({
-            command: "detect-done",
-            tool: tool.alias,
-            version: tool.version || "",
-            status: "Not installed",
-          });
-        }
-      }
+  private async probeTool(tool: DebugToolEntry): Promise<{ installed: boolean; status: string; version: string }> {
+    const result = await probeDebugToolVersion({
+      manifest: this.data,
+      tool,
+      executableName: this.getToolExecutableName(tool),
+      envData: this.envData,
+      ziBaseDir: getInternalDirRealPath(),
+      platform: getDetectPlatform(),
     });
+
+    const status = isIgnoredReferenceVersion(tool.version)
+      ? ''
+      : (result.installed
+        ? (result.updateAvailable ? 'New Version Available' : 'Installed')
+        : 'Not installed');
+
+    return {
+      installed: result.installed,
+      status,
+      version: result.version || '',
+    };
+  }
+
+  private postDetection(toolId: string, result: { status: string; version: string }) {
+    this._panel.webview.postMessage({
+      command: "detect-done",
+      tool: toolId,
+      version: result.status === 'Not installed' ? '' : result.version,
+      status: result.status,
+    });
+  }
+
+  private async refreshAliasVersion(alias: string) {
+    const aliasTool = this.getAliasProbeTool(alias);
+    if (!aliasTool) {
+      this.postDetection(alias, { status: 'Not installed', version: '' });
+      return;
+    }
+
+    const result = await probeDebugToolVersion({
+      manifest: this.data,
+      tool: aliasTool,
+      executableName: this.getExecutableName(alias),
+      envData: this.envData,
+      ziBaseDir: getInternalDirRealPath(),
+      platform: getDetectPlatform(),
+    });
+
+    this.postDetection(alias, {
+      status: result.installed
+        ? (result.updateAvailable ? 'New Version Available' : 'Installed')
+        : 'Not installed',
+      version: result.version || '',
+    });
+  }
+
+  private async refreshToolVersion(tool: DebugToolEntry) {
+    let result: { status: string; version: string };
+
+    try {
+      result = await this.probeTool(tool);
+    } catch (err) {
+      console.warn(`Version check failed for ${tool.tool}:`, err);
+      result = { status: 'Not installed', version: '' };
+    }
+
+    this.postDetection(tool.tool, result);
+
+    if (tool.alias) {
+      try {
+        await this.refreshAliasVersion(tool.alias);
+      } catch (err) {
+        console.warn(`Version check failed for ${tool.alias}:`, err);
+        this.postDetection(tool.alias, { status: 'Not installed', version: '' });
+      }
+    }
+  }
+
+  private async loadVersions() {
+    const versionPromises = this.data.debug_tools.map((tool: DebugToolEntry) => this.refreshToolVersion(tool));
 
     // Run all in parallel
     await Promise.all(versionPromises);
@@ -294,15 +300,12 @@ export class DebugToolsPanel {
       const defaultDebugToolsYml = this.data.aliases?.find((a:Aliases) => a.alias === alias)?.default;
       const defaultEnvYml = this.envData?.runners?.[alias]?.default || defaultDebugToolsYml || tools[0].tool;
 
-      // try to find parent info from Aliases (OpenOCD), then we check the default tools to use your version and status (found) to display at the parent row
-      const parentTool = this.data.debug_tools.find((t: any) => t.tool === defaultEnvYml);
-      
-      // Parent row, show version and status from default tool choosen
+      // Parent row is populated asynchronously once the selected default tool is probed.
       toolsHTML += `<tr id="row-${alias}">
         <td><button type="button" class="inline-icon-button expand-button codicon codicon-chevron-right" data-tool="${alias}" aria-label="Expand/Collapse"></button></td>
         <td id="name-${alias}">${parentToolName}</td>
-        <td id="version-${alias}">${parentTool?.version || ''}</td>
-        <td id="detect-${alias}">${parentTool?.found || ''}</td>
+        <td id="version-${alias}"></td>
+        <td id="detect-${alias}"></td>
         <td></td>
         <td><div class="progress-wheel" id="progress-${alias}"><vscode-progress-ring></vscode-progress-ring></div></td>
       </tr>`;
@@ -542,7 +545,7 @@ export class DebugToolsPanel {
           <a class="help-link" href="https://zephyr-workbench.com/docs/documentation/debug-tools">Read Docs</a>
           <form>
             <h2>Packs</h2>
-            <table class="debug-tools-table">
+            <table class="debug-tools-table packs-table">
               <tr>
                 <th></th>
                 <th>Pack</th>
@@ -633,85 +636,7 @@ export class DebugToolsPanel {
               });
               break;
             }
-
-            if (tool.alias) {
-              const alias = tool.alias;
-              const status = this.isOpenocdVariantInstalled(tool.tool) ? 'Installed' : 'Not installed';
-              webview.postMessage({
-                command: 'detect-done',
-                tool: message.tool,
-                version: '',
-                status,
-              });
-              if (this.getDefaultToolForAlias(alias) === tool.tool) {
-                webview.postMessage({
-                  command: 'detect-done',
-                  tool: alias,
-                  version: status === 'Installed' ? (tool.version || '') : '',
-                  status,
-                });
-              }
-              break;
-            }
-
-            if (tool.alias) {
-              const defaultTool = this.getDefaultToolForAlias(tool.alias);
-              if (defaultTool && tool.tool !== defaultTool) {
-                webview.postMessage({
-                  command: 'detect-done',
-                  tool: message.tool,
-                  version: tool.version || '',
-                  status: 'Not installed',
-                });
-                break;
-              }
-            }
-
-            const runnerAlias = tool?.alias || message.tool;
-
-            let runner = getRunner(runnerAlias);
-            if(runner) {
-              runner.loadArgs(undefined);
-              let version = await runner.detectVersion();
-              const expectedVersion = tool?.version || '';
-              const hasDifferentVersion = this.hasNewVersionByEnv(message.tool, expectedVersion);
-              const status = version
-                ? (hasDifferentVersion ? 'New Version Available' : 'Installed')
-                : 'Not installed';
-              let reportedVersion = version || expectedVersion || '';
-              if (status === 'Not installed') {
-                reportedVersion = '';
-              }
-              webview.postMessage({ 
-                command: 'detect-done', 
-                tool: message.tool,
-                version: reportedVersion,
-                status,
-              });
-              if (tool.alias && this.getDefaultToolForAlias(tool.alias) === tool.tool) {
-                webview.postMessage({
-                  command: 'detect-done',
-                  tool: tool.alias,
-                  version: reportedVersion,
-                  status,
-                });
-              }
-            } else {
-              webview.postMessage({
-                command: 'detect-done',
-                tool: message.tool,
-                version: tool.version || '',
-                status: 'Not installed',
-              });
-              if (tool.alias && this.getDefaultToolForAlias(tool.alias) === tool.tool) {
-                webview.postMessage({
-                  command: 'detect-done',
-                  tool: tool.alias,
-                  version: tool.version || '',
-                  status: 'Not installed',
-                });
-              }
-            }
+            await this.refreshToolVersion(tool);
             break;
           }
           case 'debug':
@@ -760,7 +685,7 @@ export class DebugToolsPanel {
                 doc = yaml.parseDocument('{}');
               }
               
-              // For OpenOCD alias, keep only runners.openocd and remove variant keys
+              // Keep only the alias entry and remove variant-specific overrides.
               if (alias) {
                 const aliasVariants = this.data.debug_tools
                   .filter((t: any) => t.alias === alias)
@@ -772,14 +697,22 @@ export class DebugToolsPanel {
 
               // Keep alias path/version aligned with the selected default variant
               const selectedTool = this.data.debug_tools.find((t: any) => t.tool === tool);
-              let selectedPath = this.getRunnerPath(tool);
-              if (!selectedPath && selectedTool) {
-                selectedPath = this.getOpenocdCommandDir(selectedTool);
-              }
-              if (tool === 'openocd-custom'){
-                doc.setIn(['runners', alias, 'path'], '');
-              } else if (selectedPath) {
+              const selectedPath = selectedTool
+                ? this.getDetectedToolCommandDir(selectedTool)
+                : undefined;
+              const hasExplicitDetect = Array.isArray(selectedTool?.['explicit-detect']?.[getDetectPlatform()]);
+
+              if (selectedPath) {
                 doc.setIn(['runners', alias, 'path'], selectedPath);
+              } else if (hasExplicitDetect) {
+                doc.deleteIn(['runners', alias, 'path']);
+              } else {
+                const configuredPath = this.getRunnerPath(tool) || this.getRunnerPath(alias);
+                if (configuredPath) {
+                  doc.setIn(['runners', alias, 'path'], configuredPath);
+                } else {
+                  doc.deleteIn(['runners', alias, 'path']);
+                }
               }
               if (selectedTool?.version) {
                 doc.setIn(['runners', alias, 'version'], selectedTool.version);
@@ -829,13 +762,6 @@ export class DebugToolsPanel {
             const success = savedPath && savedDoNotUse;
             webview.postMessage({ command: 'path-updated', tool, path: trimmedPath, success });
             if (success) {
-              // Re-detect installation/version right after saving the path
-              const runner = getRunner(tool);
-              if (runner) {
-                runner.loadArgs(undefined);
-                const version = await runner.detectVersion();
-                webview.postMessage({ command: 'detect-done', tool, version: version ? version : '' });
-              }
               // Trigger a full refresh of all runners after edit completes
               webview.postMessage({ command: 'exec-install-finished' });
             } else {
@@ -857,13 +783,6 @@ export class DebugToolsPanel {
               const ok = okPath && okDoNotUse;
               webview.postMessage({ command: 'path-updated', tool, path: chosen, success: ok, FromBrowse: true });
               if (ok) {
-                // Re-detect installation/version with the newly saved path
-                const runner = getRunner(tool);
-                if (runner) {
-                  runner.loadArgs(undefined);
-                  const version = await runner.detectVersion();
-                  webview.postMessage({ command: 'detect-done', tool, version: version ? version : '' });
-                }
                 // Trigger a full refresh of all runners after edit completes
                 webview.postMessage({ command: 'exec-install-finished' });
               }
@@ -962,97 +881,17 @@ export class DebugToolsPanel {
     return false;
   }
 
-  private hasNewVersionByEnv(toolId: string, expectedVersion: unknown): boolean {
-    try {
-      const normalize = (v: unknown) => String(v ?? '').trim().toLowerCase().replace(/^v/, '');
-      const envVersion = (this.envData as any)?.runners?.[toolId]?.version;
-      const expectedNorm = normalize(expectedVersion);
-      const envNorm = normalize(envVersion);
-      return expectedNorm.length > 0 && envNorm.length > 0 && expectedNorm !== envNorm;
-    } catch {
-      return false;
-    }
-  }
-
   private getDefaultToolForAlias(alias: string): string | undefined {
     const defaultDebugToolsYml = this.data.aliases?.find((a: Aliases) => a.alias === alias)?.default;
     const firstAliasTool = this.data.debug_tools.find((t: any) => t.alias === alias)?.tool;
     return this.envData?.runners?.[alias]?.default || defaultDebugToolsYml || firstAliasTool;
   }
 
-  // Keep the alias entry aligned with the selected OpenOCD variant. The path is
-  // derived from explicit-detect so literal and wildcard-based definitions behave
-  // the same way whether they come from .zinstaller or an external install.
-  private async ensureOpenocdAliasEntry(alias: string, defaultToolId: string): Promise<void> {
-    try {
-      const selectedTool = this.data.debug_tools.find((t: any) => t.tool === defaultToolId);
-      if (!selectedTool) { return; }
-
-      const aliasPath = this.getOpenocdCommandDir(selectedTool);
-      if (!aliasPath) { return; }
-      const aliasVersion = selectedTool.version || '';
-      const current = this.envData?.runners?.[alias];
-      const defaultFromDebugTools = this.data.aliases?.find((a: Aliases) => a.alias === alias)?.default;
-      const expectedDefault = defaultToolId !== defaultFromDebugTools ? defaultToolId : undefined;
-      const same =
-        current?.default === expectedDefault &&
-        current?.path === aliasPath &&
-        current?.version === aliasVersion;
-      if (same) { return; }
-
-      const envYamlPath = path.join(getInternalDirRealPath(), 'env.yml');
-      let doc: any;
-      if (fs.existsSync(envYamlPath)) {
-        doc = yaml.parseDocument(fs.readFileSync(envYamlPath, 'utf8'));
-      } else if (this.envYamlDoc) {
-        doc = this.envYamlDoc.clone ? this.envYamlDoc.clone() : yaml.parseDocument(String(this.envYamlDoc));
-      } else {
-        doc = yaml.parseDocument('{}');
-      }
-
-      doc.setIn(['runners', alias, 'path'], aliasPath);
-      doc.setIn(['runners', alias, 'version'], aliasVersion);
-      if (typeof doc.getIn(['runners', alias, 'do_not_use']) === 'undefined') {
-        doc.setIn(['runners', alias, 'do_not_use'], false);
-      }
-      if (defaultToolId !== defaultFromDebugTools) {
-        doc.setIn(['runners', alias, 'default'], defaultToolId);
-      } else {
-        doc.deleteIn(['runners', alias, 'default']);
-      }
-
-      formatYml(doc.contents);
-      const yamlText = yaml.stringify(yaml.parse(doc.toString()), { flow: false });
-      fs.writeFileSync(envYamlPath, yamlText, 'utf8');
-
-      this.envYamlDoc = doc;
-      try { this.envData = yaml.parse(String(doc)); } catch { this.envData = undefined; }
-    } catch {
-      // best effort only
+  private getDetectedToolCommandDir(tool: any): string | undefined {
+    const executableName = this.getToolExecutableName(tool);
+    if (!executableName) {
+      return undefined;
     }
-  }
-
-  // OpenOCD variants are considered installed when one of their explicit-detect
-  // patterns resolves to an existing path.
-  private isOpenocdVariantInstalled(toolId: string): boolean {
-    try {
-      const tool = this.data.debug_tools.find((t: any) => t.tool === toolId);
-      if (!tool) {
-        return false;
-      }
-      return !!this.getOpenocdInstallRoot(tool);
-    } 
-    catch {
-      return false;
-    }
-  }
-
-  private getOpenocdInstallRoot(tool: any): string | undefined {
-    return findDetectedToolRoot(tool, getInternalDirRealPath(), getDetectPlatform());
-  }
-
-  private getOpenocdCommandDir(tool: any): string | undefined {
-    const executableName = process.platform === 'win32' ? 'openocd.exe' : 'openocd';
     return getToolCommandDir(tool, getInternalDirRealPath(), executableName, getDetectPlatform());
   }
 

--- a/src/utils/debugToolPathUtils.ts
+++ b/src/utils/debugToolPathUtils.ts
@@ -5,6 +5,7 @@ export type DetectPlatform = 'windows' | 'linux' | 'darwin';
 
 export interface DetectableToolLike {
   install_dir?: string;
+  ['auto-detect']?: Partial<Record<DetectPlatform, string[]>>;
   ['explicit-detect']?: Partial<Record<DetectPlatform, string[]>>;
 }
 
@@ -37,7 +38,11 @@ export function preserveDetectPattern(pattern: string, ziBaseDir: string): strin
 }
 
 export function preserveDetectPatterns(patterns: string[], ziBaseDir: string): string[] {
-  return Array.from(new Set(patterns.map(pattern => preserveDetectPattern(pattern, ziBaseDir))));
+  return Array.from(new Set(
+    patterns
+      .map(pattern => preserveDetectPattern(pattern, ziBaseDir).trim())
+      .filter(pattern => pattern.length > 0)
+  ));
 }
 
 export function evaluateDetectPatterns(patterns: string[], ziBaseDir: string): string[] {
@@ -70,6 +75,11 @@ export function getToolDetectPatterns(
   const explicitDetectPaths = tool['explicit-detect']?.[platform];
   if (Array.isArray(explicitDetectPaths) && explicitDetectPaths.length > 0) {
     return preserveDetectPatterns(explicitDetectPaths, ziBaseDir);
+  }
+
+  const autoDetectPaths = tool['auto-detect']?.[platform];
+  if (Array.isArray(autoDetectPaths) && autoDetectPaths.length > 0) {
+    return preserveDetectPatterns(autoDetectPaths, ziBaseDir);
   }
 
   if (tool.install_dir) {
@@ -150,12 +160,35 @@ function deriveCommandDir(rootPath: string, executableName: string): string {
   return normalizePathSlashes(path.posix.join(normalizedRoot, 'bin'));
 }
 
+function deriveExplicitCommandDir(targetPath: string, executableName: string): string {
+  const normalizedTarget = normalizePathSlashes(targetPath);
+
+  if (looksLikeExecutablePath(normalizedTarget, executableName)) {
+    return normalizePathSlashes(path.posix.dirname(normalizedTarget));
+  }
+
+  return normalizedTarget;
+}
+
 export function getToolCommandDir(
   tool: DetectableToolLike,
   ziBaseDir: string,
   executableName: string,
   platform: DetectPlatform = getDetectPlatform(),
 ): string | undefined {
+  const explicitDetectPaths = preserveDetectPatterns(tool['explicit-detect']?.[platform] ?? [], ziBaseDir);
+  if (explicitDetectPaths.length > 0) {
+    const preservedRoot = explicitDetectPaths[0];
+    const evaluatedRoot = evaluateDetectPatterns(
+      explicitDetectPaths.filter(pattern => !hasTemplateVariable(pattern)),
+      ziBaseDir,
+    )[0];
+    const rootForEnv = (hasGlobPattern(preservedRoot) || hasTemplateVariable(preservedRoot))
+      ? preservedRoot
+      : (evaluatedRoot ?? preservedRoot);
+    return deriveExplicitCommandDir(rootForEnv, executableName);
+  }
+
   const patterns = getToolDetectPatterns(tool, platform, ziBaseDir);
   if (patterns.length === 0) {
     return undefined;

--- a/src/utils/debugToolVersionUtils.ts
+++ b/src/utils/debugToolVersionUtils.ts
@@ -1,0 +1,585 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'yaml';
+
+import { classifyShell, execCommandWithEnv, getShellExe } from './execUtils';
+import {
+  DetectPlatform,
+  DetectableToolLike,
+  evaluateDetectPatterns,
+  getDetectPlatform,
+  preserveDetectPatterns,
+} from './debugToolPathUtils';
+import { getInternalDirRealPath } from './utils';
+
+/*
+ * Shared debug-tool version probing.
+ *
+ * Global rules:
+ * - `version` in YAML is only the reference version used for update comparison.
+ * - The displayed installed version must come from an actual probe result.
+ * - Tools with `explicit-detect` are resolved only from those paths.
+ * - Tools without `explicit-detect` are resolved only by executable name, so they
+ *   are PATH-based.
+ * - Alias entries can own the shared `version-command` / `version-regex`, while a
+ *   specific child tool still provides the real executable path to probe.
+ */
+type VersionProbeSetting = string | Partial<Record<'default' | DetectPlatform, string>>;
+
+export interface DebugToolEntry extends DetectableToolLike {
+  tool: string;
+  alias?: string;
+  version?: string | number;
+  ['auto-detect']?: Partial<Record<DetectPlatform, string[]>>;
+  ['version-file']?: VersionProbeSetting;
+  ['version-command']?: VersionProbeSetting;
+  ['version-regex']?: VersionProbeSetting;
+}
+
+export interface DebugToolAliasEntry {
+  alias: string;
+  default?: string;
+  name?: string;
+  ['version-file']?: VersionProbeSetting;
+  ['version-command']?: VersionProbeSetting;
+  ['version-regex']?: VersionProbeSetting;
+}
+
+interface DebugToolsManifest {
+  debug_tools?: DebugToolEntry[];
+  aliases?: DebugToolAliasEntry[];
+}
+
+interface ToolVersionProbeResult {
+  installed: boolean;
+  version?: string;
+  updateAvailable: boolean;
+}
+
+interface ProbeConfig {
+  command?: string;
+  filePath?: string;
+  regex?: RegExp;
+}
+
+function normalizePathSlashes(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function hasExplicitDetectPatterns(
+  tool: DetectableToolLike,
+  platform: DetectPlatform,
+): boolean {
+  const patterns = preserveDetectPatterns(tool['explicit-detect']?.[platform] ?? [], getInternalDirRealPath());
+  return patterns.length > 0;
+}
+
+function quoteShellArgument(value: string): string {
+  const normalized = normalizePathSlashes(value);
+  if (!/\s/.test(normalized) && !normalized.includes('"')) {
+    return normalized;
+  }
+  return `"${normalized.replace(/"/g, '\\"')}"`;
+}
+
+function adaptProbeCommandForShell(command: string): string {
+  const shellKind = classifyShell(getShellExe());
+  if (shellKind !== 'powershell.exe' && shellKind !== 'pwsh.exe') {
+    return command;
+  }
+
+  const trimmed = command.trim();
+  if (!/^("?[A-Za-z]:\/|"?\/)/.test(trimmed)) {
+    return command;
+  }
+
+  // PowerShell needs the call operator for absolute executable paths.
+  return `& ${trimmed}`;
+}
+
+function parseDelimitedRegex(value: string): RegExp | undefined {
+  if (!value.startsWith('/')) {
+    return undefined;
+  }
+
+  const lastSlash = value.lastIndexOf('/');
+  if (lastSlash <= 0) {
+    return undefined;
+  }
+
+  const pattern = value.slice(1, lastSlash);
+  const flags = value.slice(lastSlash + 1);
+
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractComparableVersion(value: string): string | undefined {
+  const match = value.match(/\d+(?:\.\d+)+/);
+  return match?.[0];
+}
+
+function compareNumericVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(part => Number(part));
+  const rightParts = right.split('.').map(part => Number(part));
+
+  for (let idx = 0; idx < Math.max(leftParts.length, rightParts.length); idx += 1) {
+    const leftPart = leftParts[idx] || 0;
+    const rightPart = rightParts[idx] || 0;
+
+    if (leftPart > rightPart) {
+      return 1;
+    }
+    if (leftPart < rightPart) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function normalizeVersion(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase().replace(/^v/, '');
+}
+
+export function isIgnoredReferenceVersion(value: unknown): boolean {
+  return normalizeVersion(value) === 'ignore';
+}
+
+function stripWrappingQuotes(value: string): string {
+  return value.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
+}
+
+function expandConfiguredPathTemplate(
+  value: string,
+  envData: any,
+  ziBaseDir: string,
+): string | undefined {
+  const replacements: Record<string, string | undefined> = {
+    zi_base_dir: envData?.env?.zi_base_dir || ziBaseDir,
+    zi_tools_dir: envData?.env?.zi_tools_dir || path.join(ziBaseDir, 'tools'),
+    HOME: process.env.HOME || process.env.USERPROFILE,
+    USERPROFILE: process.env.USERPROFILE || process.env.HOME,
+  };
+
+  const expanded = value.replace(/\$\{([^}]+)\}/g, (match, variableName: string) => {
+    const replacement = replacements[variableName] ?? process.env[variableName];
+    return typeof replacement === 'string' && replacement.length > 0
+      ? normalizePathSlashes(replacement)
+      : match;
+  });
+
+  if (/\$\{[^}]+\}/.test(expanded)) {
+    return undefined;
+  }
+
+  return normalizePathSlashes(expanded);
+}
+
+function resolveExplicitDetectMatch(
+  tool: DetectableToolLike,
+  envData: any,
+  ziBaseDir: string,
+  platform: DetectPlatform,
+): string | undefined {
+  // `explicit-detect` can contain env.yml-style templates. We expand them first,
+  // then evaluate globs, because the probe path must match the real installed
+  // instance instead of the literal template string.
+  const explicitDetectPatterns = preserveDetectPatterns(tool['explicit-detect']?.[platform] ?? [], ziBaseDir)
+    .map(pattern => expandConfiguredPathTemplate(pattern, envData, ziBaseDir))
+    .filter((pattern): pattern is string => typeof pattern === 'string' && pattern.length > 0);
+
+  if (explicitDetectPatterns.length === 0) {
+    return undefined;
+  }
+
+  return evaluateDetectPatterns(explicitDetectPatterns, ziBaseDir)[0];
+}
+
+function getLeadingCommandToken(command: string): string | undefined {
+  const match = command.match(/^("([^"]+)"|'([^']+)'|\S+)/);
+  return match?.[1];
+}
+
+function resolveExecutablePathFromBase(basePath: string, executableName: string): string {
+  const normalizedBase = normalizePathSlashes(basePath);
+  const expectedName = executableName.toLowerCase();
+  const basename = path.posix.basename(normalizedBase).toLowerCase();
+
+  if (basename === expectedName) {
+    return normalizedBase;
+  }
+
+  if (basename === 'bin') {
+    return normalizePathSlashes(path.posix.join(normalizedBase, executableName));
+  }
+
+  if (fs.existsSync(basePath)) {
+    const stats = fs.statSync(basePath);
+    if (stats.isFile()) {
+      return normalizedBase;
+    }
+
+    const directCandidate = path.join(basePath, executableName);
+    if (fs.existsSync(directCandidate)) {
+      return normalizePathSlashes(directCandidate);
+    }
+
+    const binCandidate = path.join(basePath, 'bin', executableName);
+    if (fs.existsSync(binCandidate)) {
+      return normalizePathSlashes(binCandidate);
+    }
+
+    const binDir = path.join(basePath, 'bin');
+    if (fs.existsSync(binDir) && fs.statSync(binDir).isDirectory()) {
+      return normalizePathSlashes(path.join(binDir, executableName));
+    }
+  }
+
+  return normalizePathSlashes(path.posix.join(normalizedBase, 'bin', executableName));
+}
+
+function getDebugToolsYamlPath(): string {
+  return path.resolve(__dirname, '..', '..', 'scripts', 'runners', 'debug-tools.yml');
+}
+
+function loadDebugToolsManifest(): DebugToolsManifest {
+  const yamlFile = fs.readFileSync(getDebugToolsYamlPath(), 'utf8');
+  return yaml.parse(yamlFile) as DebugToolsManifest;
+}
+
+function findDebugTool(manifest: DebugToolsManifest, toolId: string): DebugToolEntry | undefined {
+  return manifest.debug_tools?.find(tool => tool.tool === toolId);
+}
+
+function findDebugToolAlias(manifest: DebugToolsManifest, aliasId: string): DebugToolAliasEntry | undefined {
+  return manifest.aliases?.find(alias => alias.alias === aliasId);
+}
+
+function resolveVersionProbeSetting(
+  setting: VersionProbeSetting | undefined,
+  platform: DetectPlatform = getDetectPlatform(),
+): string | undefined {
+  if (typeof setting === 'string') {
+    const trimmed = setting.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (!setting) {
+    return undefined;
+  }
+
+  const resolved = setting[platform] ?? setting.default;
+  if (typeof resolved !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = resolved.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function compileVersionRegex(rawRegex: string | undefined): RegExp | undefined {
+  if (!rawRegex) {
+    return undefined;
+  }
+
+  const delimited = parseDelimitedRegex(rawRegex);
+  if (delimited) {
+    return delimited;
+  }
+
+  try {
+    return new RegExp(rawRegex);
+  } catch {
+    return undefined;
+  }
+}
+
+function renderVersionCommand(
+  commandTemplate: string,
+  executablePath?: string,
+  executableName?: string,
+): string | undefined {
+  const trimmedTemplate = commandTemplate.trim();
+  if (trimmedTemplate.length === 0) {
+    return undefined;
+  }
+
+  const quotedExecutable = executablePath ? quoteShellArgument(executablePath) : undefined;
+
+  const leadingToken = getLeadingCommandToken(trimmedTemplate);
+  const normalizedExecutableName = executableName || (executablePath ? path.basename(executablePath) : undefined);
+  if (leadingToken && normalizedExecutableName && quotedExecutable) {
+    const unquotedToken = stripWrappingQuotes(leadingToken);
+    if (unquotedToken.toLowerCase() === normalizedExecutableName.toLowerCase()) {
+      // Keep the YAML command explicit, but if it starts with the executable name
+      // swap only that first token so alias-owned probes still run against the
+      // concrete detected binary.
+      return `${quotedExecutable}${trimmedTemplate.slice(leadingToken.length)}`;
+    }
+  }
+
+  if (!quotedExecutable || quotedExecutable.length === 0) {
+    return trimmedTemplate;
+  }
+
+  return trimmedTemplate;
+}
+
+function isReferenceVersionNewer(
+  detectedVersion: string | undefined,
+  referenceVersion: string | number | undefined,
+): boolean {
+  const detected = normalizeVersion(detectedVersion);
+  const reference = normalizeVersion(referenceVersion);
+
+  if (!detected || !reference || detected === reference) {
+    return false;
+  }
+
+  const comparableDetected = extractComparableVersion(detected);
+  const comparableReference = extractComparableVersion(reference);
+
+  if (comparableDetected && comparableReference) {
+    return compareNumericVersions(comparableDetected, comparableReference) < 0;
+  }
+
+  return detected !== reference;
+}
+
+function resolveProbeOwner(
+  manifest: DebugToolsManifest,
+  tool: DebugToolEntry,
+): DebugToolEntry | DebugToolAliasEntry | undefined {
+  // Alias metadata owns shared version parsing rules so child variants do not
+  // need to repeat the same command/regex.
+  if (tool.alias) {
+    const aliasEntry = findDebugToolAlias(manifest, tool.alias);
+    if (aliasEntry?.['version-command'] || aliasEntry?.['version-file'] || aliasEntry?.['version-regex']) {
+      return aliasEntry;
+    }
+  }
+
+  return tool;
+}
+
+function resolveVersionProbeFilePath(
+  probeOwner: DebugToolEntry | DebugToolAliasEntry | undefined,
+  envData: any,
+  ziBaseDir: string,
+  platform: DetectPlatform,
+): string | undefined {
+  if (!probeOwner) {
+    return undefined;
+  }
+
+  const fileTemplate = resolveVersionProbeSetting(probeOwner['version-file'], platform);
+  if (!fileTemplate) {
+    return undefined;
+  }
+
+  const expanded = expandConfiguredPathTemplate(fileTemplate, envData, ziBaseDir);
+  if (!expanded) {
+    return undefined;
+  }
+
+  return evaluateDetectPatterns([expanded], ziBaseDir)[0];
+}
+
+function buildProbeConfig(
+  probeOwner: DebugToolEntry | DebugToolAliasEntry | undefined,
+  executablePath?: string,
+  executableName?: string,
+  envData?: any,
+  ziBaseDir: string = getInternalDirRealPath(),
+  platform: DetectPlatform = getDetectPlatform(),
+): ProbeConfig | undefined {
+  if (!probeOwner) {
+    return undefined;
+  }
+
+  const rawRegex = resolveVersionProbeSetting(probeOwner['version-regex'], platform);
+  const filePath = resolveVersionProbeFilePath(probeOwner, envData, ziBaseDir, platform);
+  if (filePath) {
+    return {
+      filePath,
+      regex: compileVersionRegex(rawRegex),
+    };
+  }
+
+  const commandTemplate = resolveVersionProbeSetting(probeOwner['version-command'], platform);
+
+  if (!commandTemplate) {
+    return undefined;
+  }
+
+  const command = renderVersionCommand(commandTemplate, executablePath, executableName);
+  if (!command || !command.trim()) {
+    return undefined;
+  }
+
+  return {
+    command,
+    regex: compileVersionRegex(rawRegex),
+  };
+}
+
+function resolveToolExecutablePath(
+  tool: DebugToolEntry,
+  executableName: string | undefined,
+  envData: any,
+  ziBaseDir: string = getInternalDirRealPath(),
+  platform: DetectPlatform = getDetectPlatform(),
+): string | undefined {
+  if (!executableName) {
+    return undefined;
+  }
+
+  if (!hasExplicitDetectPatterns(tool, platform)) {
+    // No explicit detect means PATH-only. Alias parent rows intentionally return
+    // undefined here so they probe the bare command from PATH.
+    return tool.alias ? undefined : executableName;
+  }
+
+  const detectedRoot = resolveExplicitDetectMatch(tool, envData, ziBaseDir, platform);
+  if (!detectedRoot) {
+    return undefined;
+  }
+
+  return resolveExecutablePathFromBase(detectedRoot, executableName);
+}
+
+async function executeVersionProbe(probe: ProbeConfig): Promise<{ installed: boolean; version?: string }> {
+  return new Promise(resolve => {
+    if (probe.filePath) {
+      try {
+        const contents = fs.readFileSync(probe.filePath, 'utf8');
+        const match = probe.regex?.exec(contents);
+        const version = match?.[1]?.trim() || match?.[0]?.trim();
+        resolve({
+          installed: true,
+          version: version && version.length > 0 ? version : undefined,
+        });
+      } catch {
+        resolve({ installed: false });
+      }
+      return;
+    }
+
+    if (!probe.command?.trim()) {
+      resolve({ installed: false });
+      return;
+    }
+
+    execCommandWithEnv(adaptProbeCommandForShell(probe.command), undefined, (error, stdout, stderr) => {
+      const output = `${stdout ?? ''}\n${stderr ?? ''}`;
+      const match = probe.regex?.exec(output);
+      const version = match?.[1]?.trim() || match?.[0]?.trim();
+      if (version && version.length > 0) {
+        // Some tools print a valid version to stderr or still return a non-zero
+        // exit code for `--version`. A regex match is enough to treat the probe
+        // as successful.
+        resolve({ installed: true, version });
+        return;
+      }
+
+      if (error) {
+        resolve({ installed: false });
+        return;
+      }
+
+      resolve({
+        installed: true,
+        version: version && version.length > 0 ? version : undefined,
+      });
+    });
+  });
+}
+
+export async function probeDebugToolVersion(options: {
+  manifest: DebugToolsManifest;
+  tool: DebugToolEntry;
+  executableName?: string;
+  envData?: any;
+  ziBaseDir?: string;
+  platform?: DetectPlatform;
+}): Promise<ToolVersionProbeResult> {
+  const {
+    manifest,
+    tool,
+    executableName,
+    envData,
+    ziBaseDir = getInternalDirRealPath(),
+    platform = getDetectPlatform(),
+  } = options;
+
+  // Install detection and version probing are kept separate:
+  // - `explicit-detect` answers "is this specific tool instance present?"
+  // - the command/file probe answers "what version does it report?"
+  const installedFromDetect = hasExplicitDetectPatterns(tool, platform)
+    ? !!resolveExplicitDetectMatch(tool, envData, ziBaseDir, platform)
+    : undefined;
+  const executablePath = resolveToolExecutablePath(
+    tool,
+    executableName,
+    envData,
+    ziBaseDir,
+    platform,
+  );
+  const probeOwner = resolveProbeOwner(manifest, tool);
+  if (tool.alias && !executablePath && installedFromDetect !== true) {
+    return { installed: false, updateAvailable: false };
+  }
+
+  const probe = buildProbeConfig(probeOwner, executablePath, executableName, envData, ziBaseDir, platform);
+
+  if (!probe || (!probe.filePath && !probe.command?.trim())) {
+    return {
+      installed: installedFromDetect ?? false,
+      updateAvailable: false,
+    };
+  }
+
+  const result = await executeVersionProbe(probe);
+  const installed = installedFromDetect ?? result.installed;
+
+  return {
+    installed,
+    version: result.version,
+    updateAvailable:
+      installed &&
+      !isIgnoredReferenceVersion(tool.version) &&
+      isReferenceVersionNewer(result.version, tool.version),
+  };
+}
+
+async function probeInstalledVersion(
+  toolOrAliasId: string,
+  executablePath?: string,
+): Promise<{ installed: boolean; version?: string }> {
+  const manifest = loadDebugToolsManifest();
+  const tool = findDebugTool(manifest, toolOrAliasId);
+  const alias = tool ? undefined : findDebugToolAlias(manifest, toolOrAliasId);
+  const probeOwner = tool ? resolveProbeOwner(manifest, tool) : alias;
+  const probe = buildProbeConfig(
+    probeOwner,
+    executablePath,
+    executablePath ? path.basename(executablePath) : undefined,
+    undefined,
+    getInternalDirRealPath(),
+  );
+
+  if (!probe || (!probe.filePath && !probe.command?.trim())) {
+    return { installed: false };
+  }
+
+  return executeVersionProbe(probe);
+}
+
+export async function detectRunnerVersion(toolOrAliasId: string, executablePath?: string): Promise<string | undefined> {
+  const result = await probeInstalledVersion(toolOrAliasId, executablePath);
+  return result.version;
+}

--- a/src/webview/style.css
+++ b/src/webview/style.css
@@ -105,8 +105,37 @@ form {
 }
 
 .debug-tools-table th:nth-child(2), .debug-tools-table td:nth-child(2) {
-  width: 40%;
+  width: 36%;
   text-align: left;
+}
+
+.debug-tools-table th:nth-child(3), .debug-tools-table td:nth-child(3) {
+  width: 18%;
+}
+
+.debug-tools-table th:nth-child(4), .debug-tools-table td:nth-child(4) {
+  width: 16%;
+}
+
+.debug-tools-table th:nth-child(5), .debug-tools-table td:nth-child(5) {
+  width: 10%;
+}
+
+.packs-table th:nth-child(2), .packs-table td:nth-child(2) {
+  width: 72%;
+}
+
+.packs-table th:nth-child(3), .packs-table td:nth-child(3),
+.packs-table th:nth-child(4), .packs-table td:nth-child(4) {
+  width: 2%;
+}
+
+.packs-table th:nth-child(5), .packs-table td:nth-child(5) {
+  width: 56px;
+}
+
+.packs-table th:nth-child(6), .packs-table td:nth-child(6) {
+  width: 44px;
 }
 
 .debug-tools-table .details-row td {


### PR DESCRIPTION
This change centralizes debug-tool version detection in YAML and removes version-parsing logic from individual runners and the panel.

- Added shared version probing in [debugToolVersionUtils.ts](c:/Users/RoyJamil/Desktop/git/vscode-zephyr-workbench/src/utils/debugToolVersionUtils.ts), driven by `version-command`, `version-file`, and `version-regex` from [debug-tools.yml](c:/Users/RoyJamil/Desktop/git/vscode-zephyr-workbench/scripts/runners/debug-tools.yml).
- `version` in YAML is now only the reference version for update comparison. The displayed installed version always comes from an actual probe.
- Probe behavior is simplified:
  - tools with `explicit-detect` are resolved only from those paths
  - tools without `explicit-detect` are probed from `PATH` only
  - alias metadata like `openocd` can own shared version probe config, while variants still resolve their real detected executable
- The runners panel in [DebugToolsPanel.ts](c:/Users/RoyJamil/Desktop/git/vscode-zephyr-workbench/src/panels/DebugToolsPanel.ts) now uses the shared probe result directly for `Installed`, `Not installed`, and `New Version Available`, including alias/global rows.
- Added support for file-based version detection for special cases like `cp210x` fix #150 .
- Cleaned up runner classes by moving tool-specific version command/regex knowledge out of them and into YAML.

**TODO**
- openocd alignment
- more testing on linux + mac
