### PR TITLE
Fix Host Tools install failing when the user path contains spaces

### DIFF
--- a/src/utils/installUtils.ts
+++ b/src/utils/installUtils.ts
@@ -14,7 +14,7 @@ import { syncAutoDetectEnv } from "./debugTools/autoDetectSyncUtils";
 import { fileExists, findDefaultEnvScriptPath, getEnvScriptFilename, getInstallDirRealPath, getInternalDirRealPath, getInternalZephyrSdkInstallation, getWestWorkspace } from "./utils";
 import { getRunner } from "./debugTools/debugUtils";
 import { getZephyrTerminal } from "./zephyr/zephyrTerminalUtils";
-import { ensurePowershellExecutionPolicy } from "./powershellUtils";
+import { ensurePowershellExecutionPolicy, quotePathForPwshCommand } from "./powershellUtils";
 import { setDebugToolAliasDefault } from './debugTools/debugToolEnvUtils';
 
 export let output = vscode.window.createOutputChannel("Installing Host Tools");
@@ -428,8 +428,8 @@ export async function installHostTools(context: vscode.ExtensionContext, listToo
           return;
         }
         installScript = 'install.ps1';
-        installCmd = `powershell --% -File ${vscode.Uri.joinPath(installDirUri, installScript).fsPath}`;
-        installArgs += ` -InstallDir ${destDir}`;
+        installCmd = `powershell --% -File ${quotePathForPwshCommand(vscode.Uri.joinPath(installDirUri, installScript).fsPath)}`;
+        installArgs += ` -InstallDir ${quotePathForPwshCommand(destDir)}`;
         shell = 'powershell.exe';
         // TODO: check if powershell 7 is installed and used by default then use pwsh.exe instead
         break; 
@@ -558,8 +558,8 @@ export async function installVenv(context: vscode.ExtensionContext) {
         const ok = await ensurePowershellExecutionPolicy();
         if (!ok) { return; }
         installScript = 'install.ps1';
-        installCmd = `powershell -File ${vscode.Uri.joinPath(installDirUri, installScript).fsPath}`;
-        installArgs += ` -InstallDir ${destDir}`;
+        installCmd = `powershell -File ${quotePathForPwshCommand(vscode.Uri.joinPath(installDirUri, installScript).fsPath)}`;
+        installArgs += ` -InstallDir ${quotePathForPwshCommand(destDir)}`;
         shell = 'powershell.exe';
         break; 
       }
@@ -614,8 +614,8 @@ export async function verifyHostTools(context: vscode.ExtensionContext) {
         const ok = await ensurePowershellExecutionPolicy();
         if (!ok) { return; }
         installScript = 'install.ps1';
-        installCmd = `powershell -File ${vscode.Uri.joinPath(installDirUri, installScript).fsPath}`;
-        installArgs += `-InstallDir ${destDir}`;
+        installCmd = `powershell -File ${quotePathForPwshCommand(vscode.Uri.joinPath(installDirUri, installScript).fsPath)}`;
+        installArgs += `-InstallDir ${quotePathForPwshCommand(destDir)}`;
         shell = 'powershell.exe';
         const pwshInstalled = await checkPwshInstalled();
         if (pwshInstalled) {

--- a/src/utils/powershellUtils.ts
+++ b/src/utils/powershellUtils.ts
@@ -71,3 +71,22 @@ export async function ensurePowershellExecutionPolicy(): Promise<boolean> {
   }
   return false;
 }
+
+/**
+ * Quote a filesystem path so it survives being passed to `powershell.exe -Command`.
+ *
+ * Install commands run through a string ShellExecution as `powershell.exe -Command <cmd>`,
+ * where <cmd> is appended verbatim. The outer PowerShell parses its own command line
+ * (splitting on whitespace and dropping surrounding double quotes), then rebuilds the
+ * -Command text by joining the tokens with single spaces, without re-quoting. Plain
+ * double quotes are therefore lost, so a path containing spaces (e.g. a home directory
+ * like "C:\\Users\\First Last") gets split and the command fails with
+ * "... does not have a 'ps1' extension".
+ *
+ * Escaped double quotes (\") survive that round-trip as literal quote characters and are
+ * honored when the inner command is finally parsed, including after the stop-parsing
+ * token `--%`. Use this for any path interpolated into a PowerShell install command.
+ */
+export function quotePathForPwshCommand(p: string): string {
+  return `\\"${p}\\"`;
+}


### PR DESCRIPTION
The Windows install/verify commands interpolate the script path and -InstallDir directly into a string that is run as `powershell.exe -Command <cmd>`. VS Code appends <cmd> verbatim, so the outer PowerShell splits the arguments, drops the surrounding double quotes and rejoins them with single spaces without re-quoting. With a home directory such as "C:\Users\First Last" the path is split and the install fails with "... does not have a 'ps1' extension".

Wrap the interpolated paths with escaped double quotes via a new quotePathForPwshCommand() helper. Escaped quotes survive the -Command round-trip as literal characters and are also honored after the `--%` stop-parsing token, so paths containing spaces are passed intact.

### Reproduction
Install Host Tools on Windows where the user profile path contains a space (e.g. `C:\Users\First Last`): the task fails with `Cannot process -File 'C:\Users\First'. ... does not have a 'ps1' extension.`

### Notes
- Affects the three Windows host-tools commands: `installHostTools`, `installVenv` (reinstall venv) and `verifyHostTools` (only-check).
- Verified on Windows PowerShell 5.1 (the shell the task uses): the script path and `-InstallDir` arrive intact, including through the `--%` stop-parsing token. Non-Windows branches are untouched.